### PR TITLE
Fix func name spelling

### DIFF
--- a/llama-index-core/llama_index/core/ingestion/data_sources.py
+++ b/llama-index-core/llama_index/core/ingestion/data_sources.py
@@ -44,7 +44,7 @@ class DocumentGroup(BasePydanticReader):
         return self.documents
 
 
-def build_conifurable_data_source_enum():
+def build_configurable_data_source_enum():
     """
     Build an enum of configurable data sources.
     But conditional on if the corresponding reader is available.
@@ -337,7 +337,7 @@ def build_conifurable_data_source_enum():
     return ConfigurableComponent("ConfigurableDataSources", enum_members)
 
 
-ConfigurableDataSources = build_conifurable_data_source_enum()
+ConfigurableDataSources = build_configurable_data_source_enum()
 
 T = TypeVar("T", bound=BaseComponent)
 


### PR DESCRIPTION
Fix spelling on function name in data_sources

# Description

Fixing a spelling mistake in `llama-index-core/llama_index/core/ingestion/data_sources.py`

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

N/A

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added Google Colab support for the newly added notebooks.
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran `make format; make lint` to appease the lint gods
